### PR TITLE
changed logic part on reaching goals (reached is only re-set on a new goal position)

### DIFF
--- a/src/MotionPlanningLibraries.cpp
+++ b/src/MotionPlanningLibraries.cpp
@@ -23,6 +23,7 @@ MotionPlanningLibraries::MotionPlanningLibraries(Config config) :
         mReceivedNewTravGrid(false),
         mReceivedNewStart(false),
         mReceivedNewGoal(false),
+        mGoalReached(false),
         mArmInitialized(false),
         mReplanRequired(false),
         mLostX(0.0),
@@ -261,6 +262,16 @@ bool MotionPlanningLibraries::plan(double max_time, double& cost) {
 
     assert(mStartState.getStateType() == mGoalState.getStateType());
 
+    //if the start-goal distance was less then the mReplanMinDistStartGoal distance
+    //mGoalReached is set to true, no replans should happen, on new maps or start positions
+    if(mStartState.dist(mGoalState) <= mConfig.mReplanMinDistStartGoal) {
+    	mGoalReached = true;
+    }
+    // in case the goal is new, we cannot have reached it already
+    if (mReceivedNewGoal){
+    	mGoalReached = false;
+    }
+
     // Required checks for path planning (not required for arm movement).
     if(mConfig.mEnvType != ENV_ARM ) {
         if(mStartStateGrid.getStateType() != STATE_POSE || 
@@ -280,7 +291,7 @@ bool MotionPlanningLibraries::plan(double max_time, double& cost) {
                 mError = MPL_ERR_INITIALIZE_MAP;
                 return false;
             } else {
-                if(mStartState.dist(mGoalState) >= mConfig.mReplanMinDistStartGoal) {
+                if(!mGoalReached) {
                     mReplanRequired = true;
                 }
                 mReceivedNewTravGrid = false;
@@ -328,7 +339,7 @@ bool MotionPlanningLibraries::plan(double max_time, double& cost) {
             if(mReceivedNewGoal ||
                 (mConfig.mReplanOnNewStartPose && 
                         mReceivedNewStart && 
-                        mStartState.dist(mGoalState) >= mConfig.mReplanMinDistStartGoal)) {
+                        !mGoalReached)) {
                 mReplanRequired = true;
             }
             

--- a/src/MotionPlanningLibraries.hpp
+++ b/src/MotionPlanningLibraries.hpp
@@ -46,6 +46,7 @@ class MotionPlanningLibraries
     bool mReceivedNewTravGrid;
     bool mReceivedNewStart;
     bool mReceivedNewGoal;
+    bool mGoalReached;
     bool mArmInitialized;
     bool mReplanRequired;
     double mLostX; // Used to trac discretization error.


### PR DESCRIPTION
before, when leaving the radius by another control, the planner steered
the robot back to the last goal position
